### PR TITLE
Always load cosmetic attributes

### DIFF
--- a/yammbs/_minimize.py
+++ b/yammbs/_minimize.py
@@ -49,20 +49,11 @@ def _lazy_load_force_field(force_field_name: str) -> ForceField:
             make_unconstrained=False,
         )
 
-    if force_field_name.startswith("openff"):
-        if force_field_name in _AVAILABLE_FORCE_FIELDS:
-            return ForceField(force_field_name)
-
-        else:
-            # Attempt to load from local path, which might have "cosmetic" attributes from ForceBalance
-            return ForceField(
-                force_field_name,
-                allow_cosmetic_attributes=True,
-                load_plugins=True,
-            )
-
-    else:
-        return ForceField(force_field_name, load_plugins=True)
+    return ForceField(
+        force_field_name,
+        allow_cosmetic_attributes=True,
+        load_plugins=True,
+    )
 
 
 def _minimize_blob(


### PR DESCRIPTION
Resolves #48

The logic here looks path-dependent to me; in general there are negligible downsides to loading plugins (if there aren't any, nothing will be loaded and we're none the wiser) and loading cosmetic attributes (a little bit more is stored in memory, I guess) with high value for compatibility and flexibility.