### PR TITLE
Skip molecules with unassigned valence terms

### DIFF
--- a/yammbs/_minimize.py
+++ b/yammbs/_minimize.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 import re
 from multiprocessing import Pool
 from typing import Iterator
@@ -16,6 +17,9 @@ from yammbs._base.array import Array
 from yammbs._base.base import ImmutableModel
 
 _AVAILABLE_FORCE_FIELDS = get_available_force_fields()
+
+logger = logging.getLogger(__name__)
+logging.basicConfig()
 
 
 def _shorthand_to_full_force_field_name(
@@ -174,6 +178,7 @@ def _run_openmm(
                 combine_nonbonded_forces=False,
             )
         except UnassignedValenceError:
+            logger.warning(f"Skipping record {qcarchive_id} with unassigned valence terms")
             return None
 
     context = openmm.Context(

--- a/yammbs/_minimize.py
+++ b/yammbs/_minimize.py
@@ -1,7 +1,7 @@
 import functools
 import re
 from multiprocessing import Pool
-from typing import Union, Iterator
+from typing import Iterator, Union
 
 import numpy
 import openmm

--- a/yammbs/_tests/unit_tests/test_minimize.py
+++ b/yammbs/_tests/unit_tests/test_minimize.py
@@ -2,9 +2,8 @@ import platform
 
 import numpy
 import pytest
-from openff.toolkit import ForceField, Molecule
+from openff.toolkit import ForceField, Molecule, unit
 from openff.toolkit import __version__ as __toolkit_version__
-from openff.toolkit import unit
 
 from yammbs import MoleculeStore
 from yammbs._minimize import MinimizationInput, _run_openmm


### PR DESCRIPTION
Currently, molecules with unassigned valence terms will crash a yammbs run (see [here](https://github.com/openforcefield/yammbs-dataset-submission/actions/runs/11171315772/job/31055893576) for a temporary example). These changes should skip those molecules.

I think I should also add a test for this if you think it's a good idea in general. It might also be worth emitting a warning when a molecule is skipped.

There was some discussion in our science team meeting about how this would impact comparing force fields with different numbers of these errors, but that seems like more of a post-processing or at most a provenance issue (as Lily alluded to on slack). My vague idea is that this kind of works itself out, at least in my plotting scripts, because I usually merge the dataframes from various force field CSV files, which I think keeps only the shared record IDs. DDEs seem the most susceptible to issues, but we mentioned at the science meeting that if any conformer gets filtered out, they all should be filtered out since they share the same connectivity/parameter assignment, making it a non-issue again.

If we wanted to propagate the error farther up the callstack for later bookkeeping, I think we could return a mostly-null (`coordinates=None` and `energy=None`) `MinimizationResult` from `_run_openmm` instead of just `None`. That might fail validation currently, though.