### PR TITLE
Get Molecules from the database

### DIFF
--- a/yammbs/_db.py
+++ b/yammbs/_db.py
@@ -57,6 +57,7 @@ class DBMoleculeRecord(DBBase):  # type: ignore
                 coordinates=record.coordinates,
                 energy=record.energy,
             )
+
             self.qm_conformers.append(db_record)
 
     def store_mm_conformer_records(self, records: list[MMConformerRecord]):

--- a/yammbs/_molecule.py
+++ b/yammbs/_molecule.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING
 
-from openff.toolkit import Molecule
+from openff.toolkit import Molecule, Quantity
 
 from yammbs._base.array import Array
 
@@ -28,3 +28,14 @@ def _to_geometric_molecule(
     }
 
     return geometric_molecule
+
+
+def _molecule_with_conformer_from_smiles(
+    mapped_smiles: str,
+    conformer: Array,
+) -> Molecule:
+    """Create a molecule from mapped SMILES and attach a single conformer."""
+    molecule = Molecule.from_mapped_smiles(mapped_smiles, allow_undefined_stereo=True)
+    molecule.add_conformer(Quantity(conformer, "angstrom"))
+
+    return molecule

--- a/yammbs/_store.py
+++ b/yammbs/_store.py
@@ -9,7 +9,6 @@ import pandas
 from numpy.typing import NDArray
 from openff.qcsubmit.results import OptimizationResultCollection
 from openff.toolkit import Molecule, Quantity
-from openff.units import unit
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from typing_extensions import Self
@@ -20,6 +19,7 @@ from yammbs._db import (
     DBMoleculeRecord,
     DBQMConformerRecord,
 )
+from yammbs._molecule import _molecule_with_conformer_from_smiles
 from yammbs._session import DBSessionManager
 from yammbs._types import Pathlike
 from yammbs.analysis import (
@@ -317,9 +317,8 @@ class MoleculeStore:
                 .filter_by(qcarchive_id=id)
                 .all()
             )
-            ret = Molecule.from_mapped_smiles(smiles, allow_undefined_stereo=True)
-            ret.add_conformer(conformer * unit.angstroms)
-            return ret
+
+            return _molecule_with_conformer_from_smiles(smiles, conformer)
 
     def get_mm_molecule_by_qcarchive_id(self, id: int, force_field: str) -> Molecule:
         with self._get_session() as db:
@@ -333,9 +332,8 @@ class MoleculeStore:
                 .filter_by(force_field=force_field)
                 .all()
             )
-            ret = Molecule.from_mapped_smiles(smiles, allow_undefined_stereo=True)
-            ret.add_conformer(conformer * unit.angstroms)
-            return ret
+
+            return _molecule_with_conformer_from_smiles(smiles, conformer)
 
     # TODO: Allow by multiple selectors (id: list[int])
     def get_qm_energies_by_molecule_id(self, id: int) -> list[float]:

--- a/yammbs/_tests/unit_tests/test_store.py
+++ b/yammbs/_tests/unit_tests/test_store.py
@@ -6,6 +6,7 @@ import numpy
 import pytest
 from openff.qcsubmit.results import OptimizationResultCollection
 from openff.toolkit import Molecule
+from openff.units import unit
 from openff.utilities import get_data_file_path, has_executable, temporary_cd
 
 from yammbs import MoleculeStore
@@ -136,6 +137,32 @@ def test_get_conformers(small_store):
             molecule_id,
             force_field=force_field,
         )[-1],
+    )
+
+
+def test_get_molecules(small_store):
+    force_field = "openff-2.0.0"
+    molecule_id = 40
+    qcarchive_id = small_store.get_qcarchive_ids_by_molecule_id(molecule_id)[-1]
+
+    numpy.testing.assert_allclose(
+        small_store.get_qm_conformer_by_qcarchive_id(
+            qcarchive_id,
+        ),
+        small_store.get_qm_molecule_by_qcarchive_id(qcarchive_id).conformers[0].m_as(unit.angstroms),
+    )
+
+    numpy.testing.assert_allclose(
+        small_store.get_mm_conformer_by_qcarchive_id(
+            qcarchive_id,
+            force_field=force_field,
+        ),
+        small_store.get_mm_molecule_by_qcarchive_id(
+            qcarchive_id,
+            force_field=force_field,
+        )
+        .conformers[0]
+        .m_as(unit.angstroms),
     )
 
 

--- a/yammbs/_tests/unit_tests/test_store.py
+++ b/yammbs/_tests/unit_tests/test_store.py
@@ -6,7 +6,6 @@ import numpy
 import pytest
 from openff.qcsubmit.results import OptimizationResultCollection
 from openff.toolkit import Molecule
-from openff.units import unit
 from openff.utilities import get_data_file_path, has_executable, temporary_cd
 
 from yammbs import MoleculeStore
@@ -149,7 +148,7 @@ def test_get_molecules(small_store):
         small_store.get_qm_conformer_by_qcarchive_id(
             qcarchive_id,
         ),
-        small_store.get_qm_molecule_by_qcarchive_id(qcarchive_id).conformers[0].m_as(unit.angstroms),
+        small_store.get_qm_molecule_by_qcarchive_id(qcarchive_id).conformers[0].m_as("angstroms"),
     )
 
     numpy.testing.assert_allclose(
@@ -162,7 +161,7 @@ def test_get_molecules(small_store):
             force_field=force_field,
         )
         .conformers[0]
-        .m_as(unit.angstroms),
+        .m_as("angstroms"),
     )
 
 


### PR DESCRIPTION
Hopefully I didn't miss existing methods for this, but this is just an idea I had to address the quantity use case in #67. I copy-pasted `get_*m_conformer_by_qcarchive_id` as the base for these since I needed to add another field to the `query`, but I guess these could actually be used in the conformer versions with `.conformers[0].m_as(unit.angstrom)` like the test to avoid some duplication.