### PR TITLE
Drop Intel macOS image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,18 +23,13 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macOS-12
-          - macOS-latest
+          - macos-13
+          - macos-latest
           - ubuntu-latest
         python-version:
           - "3.10"
           - "3.11"
           - "3.12"
-        exclude:
-          - os: macOS-12
-            python-version: "3.12"
-          - os: mac-latest
-            python-version: "3.12"
 
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
           - macos-latest
           - ubuntu-latest
         python-version:


### PR DESCRIPTION
AmberTools is causing major issues on the `macos-13` runner. I'm making the executive decision to not support it in this project.