### PR TITLE
Speed up loading a `MoleculeStore` from a `QCArchiveDataset`

### DIFF
--- a/yammbs/_store.py
+++ b/yammbs/_store.py
@@ -557,7 +557,6 @@ class MoleculeStore:
                     inchi_key=molecule.to_inchi(fixed_hydrogens=True),
                 )
                 db.db.add(db_record)
-                db.db.commit()
 
         # close the session here and re-open to make sure all of the molecule
         # IDs have been flushed to the db

--- a/yammbs/_store.py
+++ b/yammbs/_store.py
@@ -566,11 +566,6 @@ class MoleculeStore:
         # QMConformerRecord.from_qcarchive_record, and
         # DBSessionManager.store_qm_conformer_record
         with store._get_session() as db:
-            seen = set(
-                db.db.query(
-                    DBQMConformerRecord.qcarchive_id,
-                ),
-            )
             # reversed so the first record encountered wins out. this matches
             # the behavior of the version that queries the db each time
             smiles_to_id = {
@@ -583,9 +578,6 @@ class MoleculeStore:
                 )
             }
             for record in tqdm(dataset.qm_molecules, desc="Storing Records"):
-                if record.qcarchive_id in seen:
-                    continue
-                seen.add(record.qcarchive_id)
                 mol_id = smiles_to_id[record.mapped_smiles]
                 db.db.add(
                     DBQMConformerRecord(

--- a/yammbs/_store.py
+++ b/yammbs/_store.py
@@ -533,7 +533,7 @@ class MoleculeStore:
         """
         Create a new MoleculeStore databset from YAMMBS's QCArchiveDataset model.
 
-        Largely adopted from `from_qcsubmit_collection`.
+        Largely adopted from `from_cached_result_collection`.
         """
         from tqdm import tqdm
 
@@ -542,24 +542,60 @@ class MoleculeStore:
 
         store = cls(database_name)
 
-        for qm_molecule in tqdm(dataset.qm_molecules, desc="Storing molecules"):
-            molecule = Molecule.from_mapped_smiles(qm_molecule.mapped_smiles, allow_undefined_stereo=True)
-            molecule.add_conformer(Quantity(qm_molecule.coordinates, "angstrom"))
-
-            molecule_record = MoleculeRecord.from_molecule(molecule)
-            store.store(molecule_record)
-
-            store.store_qcarchive(
-                QMConformerRecord(
-                    molecule_id=store.get_molecule_id_by_smiles(
-                        molecule_record.mapped_smiles,
-                    ),
-                    qcarchive_id=qm_molecule.qcarchive_id,
+        # adapted from MoleculeRecord.from_molecule, MoleculeStore.store, and
+        # DBSessionManager.store_molecule_record
+        with store._get_session() as db:
+            # instead of DBSessionManager._smiles_already_exists
+            seen = set(db.db.query(DBMoleculeRecord.mapped_smiles))
+            for qm_molecule in tqdm(dataset.qm_molecules, desc="Storing molecules"):
+                if qm_molecule.mapped_smiles in seen:
+                    continue
+                seen.add(qm_molecule.mapped_smiles)
+                molecule = Molecule.from_mapped_smiles(qm_molecule.mapped_smiles, allow_undefined_stereo=True)
+                db_record = DBMoleculeRecord(
                     mapped_smiles=qm_molecule.mapped_smiles,
-                    coordinates=qm_molecule.coordinates,
-                    energy=qm_molecule.final_energy,
+                    inchi_key=molecule.to_inchi(fixed_hydrogens=True),
+                )
+                db.db.add(db_record)
+                db.db.commit()
+
+        # close the session here and re-open to make sure all of the molecule
+        # IDs have been flushed to the db
+
+        # adapted from MoleculeStore.store_qcarchive,
+        # QMConformerRecord.from_qcarchive_record, and
+        # DBSessionManager.store_qm_conformer_record
+        with store._get_session() as db:
+            seen = set(
+                db.db.query(
+                    DBQMConformerRecord.qcarchive_id,
                 ),
             )
+            # reversed so the first record encountered wins out. this matches
+            # the behavior of the version that queries the db each time
+            smiles_to_id = {
+                smi: id
+                for id, smi in reversed(
+                    db.db.query(
+                        DBMoleculeRecord.id,
+                        DBMoleculeRecord.mapped_smiles,
+                    ).all(),
+                )
+            }
+            for record in tqdm(dataset.qm_molecules, desc="Storing Records"):
+                if record.qcarchive_id in seen:
+                    continue
+                seen.add(record.qcarchive_id)
+                mol_id = smiles_to_id[record.mapped_smiles]
+                db.db.add(
+                    DBQMConformerRecord(
+                        parent_id=mol_id,
+                        qcarchive_id=record.qcarchive_id,
+                        mapped_smiles=record.mapped_smiles,
+                        coordinates=record.coordinates,
+                        energy=record.final_energy,
+                    ),
+                )
 
         return store
 

--- a/yammbs/_store.py
+++ b/yammbs/_store.py
@@ -8,7 +8,7 @@ import numpy
 import pandas
 from numpy.typing import NDArray
 from openff.qcsubmit.results import OptimizationResultCollection
-from openff.toolkit import Molecule, Quantity
+from openff.toolkit import Molecule
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from typing_extensions import Self

--- a/yammbs/_tests/unit_tests/test_store.py
+++ b/yammbs/_tests/unit_tests/test_store.py
@@ -57,6 +57,8 @@ def test_from_qcarchive_dataset(small_qcsubmit_collection):
         # Ensure a new object can be created from the same database
         assert len(MoleculeStore(db)) == len(store)
 
+        assert len(store.get_smiles()) == small_qcsubmit_collection.n_molecules
+
 
 def test_from_qcarchive_dataset_undefined_stereo():
     """Test loading from YAMMBS's QCArchive model with undefined stereochemistry"""


### PR DESCRIPTION
The changes here are analogous to (and copied from) those in #21. As before, the source of the improvements is holding the DB session for multiple insertions instead of inserting one record at a time. I felt a little bad copy-pasting, but I think `CachedResultCollection` is deprecated and likely to be removed soon anyway.

I also modified one of the tests because it wasn't failing when I added an early return to `from_qcarchive_dataset` that returned an empty `MoleculeStore`.

In terms of speedup, I'm seeing almost 20x in the following script:

``` python
import time

from yammbs import MoleculeStore
from yammbs.inputs import QCArchiveDataset

ds = (
    "/home/brent/omsf/clone/yammbs-dataset-submission/datasets/"
    "OpenFF-Industry-Benchmark-Season-1-v1.1/cache.json"
)

with open(ds) as inp:
    qca = QCArchiveDataset.model_validate_json(inp.read())

start = time.time()
MoleculeStore.from_qcarchive_dataset(qca, "try.sqlite")

print(start - time.time())
```

The old version of the code took 2751.4 seconds to load [cache.json](https://github.com/openforcefield/yammbs-dataset-submission/tree/master/datasets/OpenFF-Industry-Benchmark-Season-1-v1.1) from YDS, while the new version only took 143.7 seconds. These numbers are from my desktop, but the "old" value aligns well with storing the molecules taking about 45 minutes on AWS in YDS too.