### PR TITLE
Minor f-string patch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   hooks:
   - id: setup-cfg-fmt
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.4
+  rev: v0.11.5
   hooks:
     - id: ruff
       args: ['--fix']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,5 @@ build-backend = "setuptools.build_meta"
 line-length = 119
 
 [tool.ruff.lint]
-select = ["F", "E", "W", "NPY", "UP", "I"]
+preview = true
+select = ["F", "E", "W", "NPY", "UP", "I", "RUF027"]

--- a/yammbs/torsion/_store.py
+++ b/yammbs/torsion/_store.py
@@ -42,7 +42,7 @@ class TorsionStore:
                 f"Only paths to SQLite databases ending in .sqlite are supported. Given: {database_path}",
             )
 
-        LOGGER.info("Creating a new TorsionStore at {database_path=}")
+        LOGGER.info(f"Creating a new TorsionStore at {database_path=}")
 
         self.database_url = f"sqlite:///{database_path.resolve()}"
         self.engine = create_engine(self.database_url)


### PR DESCRIPTION
Closes #120 

If this is ever an issue in the future, I think this regex should be a good starting point:

```console
$ git checkout upstream/main && grep -ri "logg.*(\".*{" yammbs/ && git checkout f-string-patch && grep -ri "logg.*(\".*{" yammbs/
HEAD is now at d55651b Drop Python 3.10 from testing (#112)
yammbs//torsion/_store.py:        LOGGER.info("Creating a new TorsionStore at {database_path=}")
Previous HEAD position was d55651b Drop Python 3.10 from testing (#112)
Switched to branch 'f-string-patch'
$
```

`-i` make it case-insensitive (sometimes I use `LOGGER` for whatever reason), `-r` makes it recurse through all files in the path, and the pattern attempts to find something that has `("` in a `logger`/`logging` call but with a bracket in the string, i.e. something that's probably meant to be an f-string but isn't tagged as such.
