### PR TITLE
Add Torsion Analysis Metrics

### DIFF
--- a/devtools/conda-envs/dev.yaml
+++ b/devtools/conda-envs/dev.yaml
@@ -22,6 +22,7 @@ dependencies:
 
   - geometric =1
   - pydantic =2
+  - click
 
   - qcportal ~=0.55
 

--- a/devtools/conda-envs/dev.yaml
+++ b/devtools/conda-envs/dev.yaml
@@ -23,6 +23,7 @@ dependencies:
   - geometric =1
   - pydantic =2
   - click
+  - scipy
 
   - qcportal ~=0.55
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,11 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "yammbs"
+version = "0.1.0"
+readme = "README.md"
+
 [tool.versioningit]
 
 [tool.ruff]
@@ -12,3 +17,6 @@ line-length = 119
 
 [tool.ruff.lint]
 select = ["F", "E", "W", "NPY", "UP", "I"]
+
+[project.scripts]
+run_torsion_comparisons = "yammbs.scripts.run_torsion_comparisons:main"

--- a/yammbs/_tests/unit_tests/torsion/test_store.py
+++ b/yammbs/_tests/unit_tests/torsion/test_store.py
@@ -1,5 +1,6 @@
 import os
 
+import pytest
 from openff.qcsubmit.results import TorsionDriveResultCollection
 from openff.utilities import get_data_file_path
 
@@ -56,3 +57,19 @@ def test_minimize_basic(single_torsion_dataset, tmp_path):
 
     assert len(metrics["metrics"]) == 1
     assert len(metrics["metrics"]["openff-2.2.0"]) == 1
+
+    expected_metrics = {
+        "rmsd": 0.07475493617511018,
+        "rmse": 0.8193199571663233,
+        "mean_error": -0.35170719027937586,
+        "js_distance": (0.3168201337322116, 500.0),
+    }
+
+    assert len(expected_metrics) == len(metrics["metrics"]["openff-2.2.0"][1])
+
+    for metric in metrics["metrics"]["openff-2.2.0"][1]:
+        assert metric in expected_metrics
+        assert metrics["metrics"]["openff-2.2.0"][1][metric] == pytest.approx(
+            expected_metrics[metric],
+            rel=1e-5,
+        )

--- a/yammbs/scripts/run_torsion_comparisons.py
+++ b/yammbs/scripts/run_torsion_comparisons.py
@@ -99,7 +99,7 @@ def main(
     plot_cdfs(force_fields, output_metrics, plot_dir)
     plot_rms_stats(force_fields, output_metrics, plot_dir)
     plot_mean_error_distribution(force_fields, output_metrics, plot_dir)
-    plot_mean_js_divergence(force_fields, output_metrics, plot_dir)
+    plot_rms_js_distance(force_fields, output_metrics, plot_dir)
 
 
 def get_torsion_image(molecule_id: int, store: TorsionStore) -> pyplot.Figure:
@@ -229,12 +229,12 @@ def plot_torsions(plot_dir: str, force_fields: list[str], store: TorsionStore) -
 def plot_cdfs(force_fields: list[str], metrics_file: str, plot_dir: str):
     metrics = MetricCollection.parse_file(metrics_file)
 
-    x_ranges = {"rmsd": (0, 0.14), "rmse": (-0.3, 5), "js_divergence": (None, None)}
+    x_ranges = {"rmsd": (0, 0.14), "rmse": (-0.3, 5), "js_distance": (None, None)}
 
     units = {
         "rmsd": r"$\mathrm{\AA}$",
         "rmse": r"kcal mol$^{-1}$",
-        "js_divergence": "",
+        "js_distance": "",
     }
 
     rmsds = {
@@ -247,19 +247,19 @@ def plot_cdfs(force_fields: list[str], metrics_file: str, plot_dir: str):
         for force_field in metrics.metrics.keys()
     }
 
-    js_divs = {
-        force_field: {key: val.js_divergence[0] for key, val in metrics.metrics[force_field].items()}
+    js_dists = {
+        force_field: {key: val.js_distance[0] for key, val in metrics.metrics[force_field].items()}
         for force_field in metrics.metrics.keys()
     }
 
-    js_div_temp = list(list(metrics.metrics.values())[0].values())[0].js_divergence[1]
+    js_div_temp = list(list(metrics.metrics.values())[0].values())[0].js_distance[1]
 
     data = {
         "rmsd": rmsds,
         "rmse": rmses,
-        "js_divergence": js_divs,
+        "js_distance": js_dists,
     }
-    for key in ["rmsd", "rmse", "js_divergence"]:
+    for key in ["rmsd", "rmse", "js_distance"]:
         figure, axis = pyplot.subplots()
 
         for force_field in force_fields:
@@ -290,8 +290,8 @@ def plot_cdfs(force_fields: list[str], metrics_file: str, plot_dir: str):
 
                 x_label = (
                     key.upper() + " / " + units[key]
-                    if key != "js_divergence"
-                    else f"Jensen-Shannon Divergence at {js_div_temp} K"
+                    if key != "js_distance"
+                    else f"Jensen-Shannon Distance at {js_div_temp} K"
                 )
                 axis.set_xlabel(x_label)
                 axis.set_ylabel("CDF")
@@ -349,32 +349,32 @@ def plot_rms_stats(
         figure.savefig(f"{plot_dir}/{key}_rms.png", dpi=300, bbox_inches="tight")
 
 
-def plot_mean_js_divergence(
+def plot_rms_js_distance(
     force_fields: list[str],
     metrics_file: str,
     plot_dir: str,
 ) -> None:
     metrics = MetricCollection.parse_file(metrics_file)
 
-    mean_js_divergences = {
-        force_field: np.mean([val.js_divergence[0] for val in metrics.metrics[force_field].values()])
+    rms_js_distance = {
+        force_field: get_rms(np.array([val.js_distance[0] for val in metrics.metrics[force_field].values()]))
         for force_field in force_fields
     }
 
-    js_div_temp = list(list(metrics.metrics.values())[0].values())[0].js_divergence[1]
+    js_div_temp = list(list(metrics.metrics.values())[0].values())[0].js_distance[1]
 
-    # Plot mean JS divergence
+    # Plot mean JS distance
     figure, axis = pyplot.subplots()
 
-    axis.bar(mean_js_divergences.keys(), mean_js_divergences.values(), color=pyplot.cm.tab10.colors)
-    axis.set_ylabel(f"Mean Jensen-Shannon Divergence at {js_div_temp} K")
+    axis.bar(rms_js_distance.keys(), rms_js_distance.values(), color=pyplot.cm.tab10.colors)
+    axis.set_ylabel(f"Mean Jensen-Shannon Distance at {js_div_temp} K")
 
     # Set x-ticks to be vertical
     pyplot.xticks(rotation=90)
 
     # Save the figure
     figure.tight_layout()
-    figure.savefig(f"{plot_dir}/mean_js_divergence.png", dpi=300, bbox_inches="tight")
+    figure.savefig(f"{plot_dir}/mean_js_distance.png", dpi=300, bbox_inches="tight")
 
 
 def plot_mean_error_distribution(

--- a/yammbs/scripts/run_torsion_comparisons.py
+++ b/yammbs/scripts/run_torsion_comparisons.py
@@ -5,7 +5,6 @@ import click
 import numpy as np
 from matplotlib import pyplot
 from openff.toolkit import Molecule
-from rdkit import Chem
 from rdkit.Chem import AllChem, Draw
 
 from yammbs.torsion import TorsionStore
@@ -230,11 +229,7 @@ def plot_torsions(plot_dir: str, force_fields: list[str], store: TorsionStore) -
 def plot_cdfs(force_fields: list[str], metrics_file: str, plot_dir: str):
     metrics = MetricCollection.parse_file(metrics_file)
 
-    x_ranges = {
-        "rmsd": (0, 0.14),
-        "rmse": (-0.3, 5),
-        "js_divergence": (None, None)
-    }
+    x_ranges = {"rmsd": (0, 0.14), "rmse": (-0.3, 5), "js_divergence": (None, None)}
 
     units = {
         "rmsd": r"$\mathrm{\AA}$",
@@ -293,7 +288,11 @@ def plot_cdfs(force_fields: list[str], metrics_file: str, plot_dir: str):
                     label=force_field,
                 )
 
-                x_label = key.upper() + " / " + units[key] if key != "js_divergence" else f"Jensen-Shannon Divergence at {js_div_temp} K"
+                x_label = (
+                    key.upper() + " / " + units[key]
+                    if key != "js_divergence"
+                    else f"Jensen-Shannon Divergence at {js_div_temp} K"
+                )
                 axis.set_xlabel(x_label)
                 axis.set_ylabel("CDF")
 
@@ -349,16 +348,13 @@ def plot_rms_stats(
         figure.tight_layout()
         figure.savefig(f"{plot_dir}/{key}_rms.png", dpi=300, bbox_inches="tight")
 
+
 def plot_mean_js_divergence(
     force_fields: list[str],
     metrics_file: str,
     plot_dir: str,
 ) -> None:
     metrics = MetricCollection.parse_file(metrics_file)
-
-    units = {
-        "mean_js_divergence": "",
-    }
 
     mean_js_divergences = {
         force_field: np.mean([val.js_divergence[0] for val in metrics.metrics[force_field].values()])

--- a/yammbs/scripts/run_torsion_comparisons.py
+++ b/yammbs/scripts/run_torsion_comparisons.py
@@ -9,14 +9,23 @@ from yammbs.torsion import TorsionStore
 from yammbs.torsion.inputs import QCArchiveTorsionDataset
 from yammbs.torsion.outputs import MetricCollection
 
+pyplot.style.use("ggplot")
+
 
 @click.command()
 @click.option(
-    "--force-fields",
-    "-f",
+    "--base-force-fields",
+    "-bf",
     multiple=True,
-    default=["openff-1.0.0", "openff-2.0.0", "openff-2.1.0", "openff-2.2.0", "openff-2.2.1"],
+    default=["openff-1.0.0", "openff-2.0.0", "openff-2.1.0", "openff-2.2.1"],
     help="List of force fields to use for optimization.",
+)
+@click.option(
+    "--extra-force-fields",
+    "-ef",
+    multiple=True,
+    default=[],
+    help="Extra (local) force fields to use for optimization.",
 )
 @click.option(
     "--qcarchive-torsion-data",
@@ -49,7 +58,8 @@ from yammbs.torsion.outputs import MetricCollection
     help="Directory to save the generated plots.",
 )
 def main(
-    force_fields: list[str],
+    base_force_fields: list[str],
+    extra_force_fields: list[str],
     qcarchive_torsion_data: str,
     database_file: str,
     output_metrics: str,
@@ -59,6 +69,8 @@ def main(
     """
     Run torsion drive comparisons using specified force fields and input data.
     """
+    force_fields = base_force_fields + extra_force_fields
+
     dataset = QCArchiveTorsionDataset.model_validate_json(open(qcarchive_torsion_data).read())
 
     if pathlib.Path(database_file).exists():
@@ -80,6 +92,13 @@ def main(
         with open(output_metrics, "w") as f:
             f.write(store.get_metrics().model_dump_json())
 
+    # Plot!
+    plot_torsions(plot_dir, force_fields, store)
+    plot_cdfs(force_fields, output_metrics, plot_dir)
+    plot_rms_stats(output_metrics, plot_dir)
+
+
+def plot_torsions(plot_dir: str, force_fields: list[str], store: TorsionStore) -> None:
     fig, axes = pyplot.subplots(5, 4, figsize=(20, 20))
 
     for molecule_id, axis in zip(store.get_molecule_ids(), axes.flatten()):
@@ -92,8 +111,12 @@ def main(
         # Make a new dict to avoid in-place modification while iterating
         qm = {key: _qm[key] - _qm[qm_minimum_index] for key in _qm}
 
+        # Assume a default grid spacing of 15 degrees (BespokeFit default)
+        angles = np.arange(-165, 195, 15)
+        assert len(angles) == len(qm), "QM data and angles should match in length"
+
         axis.plot(
-            qm.keys(),
+            angles,
             qm.values(),
             "k.-",
             label=f"QM {molecule_id}",
@@ -105,26 +128,32 @@ def main(
                 continue
 
             axis.plot(
-                mm.keys(),
+                angles,
                 [val - mm[qm_minimum_index] for val in mm.values()],
                 "o--",
                 label=force_field,
             )
 
         axis.legend(loc=0)
-        axis.grid(axis="both")
+
+        # Label the axes
+        axis.set_ylabel(r"Energy / kcal mol$^{-1}$")
+        axis.set_xlabel("Torsion angle / degrees")
 
     fig.savefig(f"{plot_dir}/random.png")
 
-    plot_cdf(force_fields, output_metrics, plot_dir)
 
-
-def plot_cdf(force_fields: list[str], metrics_file: str, plot_dir: str):
+def plot_cdfs(force_fields: list[str], metrics_file: str, plot_dir: str):
     metrics = MetricCollection.parse_file(metrics_file)
 
     x_ranges = {
-        "rmsd": (0, 0.18),
+        "rmsd": (0, 0.14),
         "rmse": (-0.3, 5),
+    }
+
+    units = {
+        "rmsd": r"$\mathrm{\AA}$",
+        "rmse": r"kcal mol$^{-1}$",
     }
 
     rmsds = {
@@ -170,7 +199,7 @@ def plot_cdf(force_fields: list[str], metrics_file: str, plot_dir: str):
                     label=force_field,
                 )
 
-                axis.set_xlabel(key)
+                axis.set_xlabel(key.upper() + " / " + units[key])
                 axis.set_ylabel("CDF")
 
                 axis.set_xlim(x_ranges[key])
@@ -181,10 +210,53 @@ def plot_cdf(force_fields: list[str], metrics_file: str, plot_dir: str):
         figure.savefig(f"{plot_dir}/{key}.png", dpi=300)
 
 
+def get_rms(array: np.ndarray) -> float:
+    """
+    Calculate the root mean square of an array.
+    """
+    return np.sqrt(np.mean(array**2))
+
+
+def plot_rms_stats(
+    metrics_file: str,
+    plot_dir: str,
+) -> None:
+    metrics = MetricCollection.parse_file(metrics_file)
+
+    units = {
+        "rmsd": r"$\mathrm{\AA}$",
+        "rmse": r"kcal mol$^{-1}$",
+    }
+
+    rms_rmses = {
+        force_field: get_rms(np.array([val.rmse for val in metrics.metrics[force_field].values()]))
+        for force_field in metrics.metrics.keys()
+    }
+
+    rms_rmsds = {
+        force_field: get_rms(np.array([val.rmsd for val in metrics.metrics[force_field].values()]))
+        for force_field in metrics.metrics.keys()
+    }
+
+    # Plot RMS values
+    for key, data in zip(["rmsd", "rmse"], [rms_rmsds, rms_rmses]):
+        figure, axis = pyplot.subplots()
+
+        # Use different colors for each bar - the same as for the CDFs
+        axis.bar(data.keys(), data.values(), color=pyplot.cm.tab10.colors)
+        axis.set_ylabel(key.upper() + " / " + units[key])
+
+        # Set x-ticks to be vertical
+        pyplot.xticks(rotation=90)
+
+        # Save the figure
+        figure.tight_layout()
+        figure.savefig(f"{plot_dir}/{key}_rms.png", dpi=300, bbox_inches="tight")
+
+
 if __name__ == "__main__":
     # This setup is necessary for reasons that confused me - both setting it up in the __main__ block and calling
     # freeze_support(). This is probably not necessary after MoleculeStore.optimize_mm() is called, so you can load up
     # the same database for later analysis once the MM conformers are stored
-    pyplot.style.use("ggplot")
     freeze_support()
     main()

--- a/yammbs/scripts/run_torsion_comparisons.py
+++ b/yammbs/scripts/run_torsion_comparisons.py
@@ -356,6 +356,10 @@ def plot_mean_js_divergence(
 ) -> None:
     metrics = MetricCollection.parse_file(metrics_file)
 
+    units = {
+        "mean_js_divergence": "",
+    }
+
     mean_js_divergences = {
         force_field: np.mean([val.js_divergence[0] for val in metrics.metrics[force_field].values()])
         for force_field in force_fields

--- a/yammbs/scripts/run_torsion_comparisons.py
+++ b/yammbs/scripts/run_torsion_comparisons.py
@@ -96,6 +96,7 @@ def main(
     plot_torsions(plot_dir, force_fields, store)
     plot_cdfs(force_fields, output_metrics, plot_dir)
     plot_rms_stats(output_metrics, plot_dir)
+    plot_mean_error_distribution(output_metrics, plot_dir)
 
 
 def plot_torsions(plot_dir: str, force_fields: list[str], store: TorsionStore) -> None:
@@ -252,6 +253,39 @@ def plot_rms_stats(
         # Save the figure
         figure.tight_layout()
         figure.savefig(f"{plot_dir}/{key}_rms.png", dpi=300, bbox_inches="tight")
+
+
+def plot_mean_error_distribution(
+    metrics_file: str,
+    plot_dir: str,
+) -> None:
+    metrics = MetricCollection.parse_file(metrics_file)
+
+    units = {
+        "mean_error": r"kcal mol$^{-1}$",
+    }
+
+    mean_errors = {
+        force_field: np.array([val.mean_error for val in metrics.metrics[force_field].values()])
+        for force_field in metrics.metrics.keys()
+    }
+    # Plot mean error distribution using kernel density estimation
+    figure, axis = pyplot.subplots()
+    import seaborn as sns
+
+    for force_field in mean_errors.keys():
+        sns.kdeplot(
+            data=mean_errors[force_field],
+            label=force_field,
+            ax=axis,
+        )
+    axis.set_xlabel("Mean Error / " + units["mean_error"])
+    axis.set_ylabel("Density")
+    axis.legend(loc=0)
+
+    # Save the figure
+    figure.tight_layout()
+    figure.savefig(f"{plot_dir}/mean_error_distribution.png", dpi=300, bbox_inches="tight")
 
 
 if __name__ == "__main__":

--- a/yammbs/scripts/run_torsion_comparisons.py
+++ b/yammbs/scripts/run_torsion_comparisons.py
@@ -19,7 +19,7 @@ pyplot.style.use("ggplot")
     "--base-force-fields",
     "-bf",
     multiple=True,
-    default=["openff-1.0.0", "openff-2.0.0", "openff-2.1.0", "openff-2.2.1"],
+    default=["openff-1.0.0", "openff-2.0.0", "openff-2.1.0", "openff-2.2.0", "openff-2.2.1"],
     help="List of force fields to use for optimization.",
 )
 @click.option(
@@ -356,10 +356,6 @@ def plot_mean_js_divergence(
 ) -> None:
     metrics = MetricCollection.parse_file(metrics_file)
 
-    units = {
-        "mean_js_divergence": "",
-    }
-
     mean_js_divergences = {
         force_field: np.mean([val.js_divergence[0] for val in metrics.metrics[force_field].values()])
         for force_field in force_fields
@@ -397,7 +393,7 @@ def plot_mean_error_distribution(
         for force_field in force_fields
     }
     # Plot mean error distribution using kernel density estimation
-    figure, axis = pyplot.subplots()
+    figure, axis = pyplot.subplots(figsize=(10, 4))
     import seaborn as sns
 
     for force_field in mean_errors.keys():
@@ -408,7 +404,7 @@ def plot_mean_error_distribution(
         )
     axis.set_xlabel("Mean Error / " + units["mean_error"])
     axis.set_ylabel("Density")
-    axis.legend(loc=0)
+    axis.legend(bbox_to_anchor=(1.05, 1), loc="upper left")
 
     # Save the figure
     figure.tight_layout()

--- a/yammbs/torsion/_store.py
+++ b/yammbs/torsion/_store.py
@@ -24,6 +24,8 @@ from yammbs.torsion._session import TorsionDBSessionManager
 from yammbs.torsion.analysis import (
     RMSD,
     RMSE,
+    JSDivergence,
+    JSDivergenceCollection,
     MeanError,
     MeanErrorCollection,
     RMSDCollection,
@@ -472,16 +474,16 @@ class TorsionStore:
         return mean_errors
 
     def _get_js_divergence(
-            self,
-            qm: numpy.ndarray,
-            mm: numpy.ndarray,
-            temperature: float = 500.0,
+        self,
+        qm: numpy.ndarray,
+        mm: numpy.ndarray,
+        temperature: float = 500.0,
     ) -> float:
         """Return the Jensen-Shannon divergence between two distributions."""
         from scipy.spatial.distance import jensenshannon
 
         beta = 1.0 / (temperature * 0.0019872041)  # kcal/mol to K
-        
+
         # Get normalised probabilities by Boltzmann inversion
         p_qm, p_mm = numpy.exp(-beta * qm), numpy.exp(-beta * mm)
         p_qm /= p_qm.sum()
@@ -489,7 +491,6 @@ class TorsionStore:
 
         # Return square as scipy gives us the sqrt of the divergence
         return jensenshannon(p_qm, p_mm) ** 2
-
 
     def get_js_divergence(
         self,
@@ -535,7 +536,6 @@ class TorsionStore:
             )
 
         return divergences
-
 
     def get_outputs(self) -> MinimizedTorsionDataset:
         from yammbs.torsion.outputs import MinimizedTorsionProfile

--- a/yammbs/torsion/_store.py
+++ b/yammbs/torsion/_store.py
@@ -21,7 +21,7 @@ from yammbs.torsion._db import (
     DBTorsionRecord,
 )
 from yammbs.torsion._session import TorsionDBSessionManager
-from yammbs.torsion.analysis import RMSE, RMSD, RMSECollection, RMSDCollection, _normalize
+from yammbs.torsion.analysis import RMSD, RMSE, RMSDCollection, RMSECollection, _normalize
 from yammbs.torsion.inputs import QCArchiveTorsionDataset
 from yammbs.torsion.models import MMTorsionPointRecord, QMTorsionPointRecord, TorsionRecord
 from yammbs.torsion.outputs import Metric, MetricCollection, MinimizedTorsionDataset
@@ -417,7 +417,7 @@ class TorsionStore:
             rmses.append(
                 RMSE(
                     id=molecule_id,
-                    rmse=numpy.sqrt(((qm - mm)**2).mean()),
+                    rmse=numpy.sqrt(((qm - mm) ** 2).mean()),
                 ),
             )
 

--- a/yammbs/torsion/analysis.py
+++ b/yammbs/torsion/analysis.py
@@ -49,19 +49,19 @@ class RMSDCollection(list[RMSD]):
         self.to_dataframe().to_csv(path)
 
 
-class EEN(ImmutableModel):
+class RMSE(ImmutableModel):
     id: int
-    een: float
+    rmse: float
 
 
-class EENCollection(list[EEN]):
+class RMSECollection(list[RMSE]):
     def to_dataframe(self) -> "pandas.DataFrame":
         import pandas
 
         return pandas.DataFrame(
-            [een.een for een in self],
-            index=pandas.Index([een.id for een in self]),
-            columns=["een"],
+            [rmse.rmse for rmse in self],
+            index=pandas.Index([rmse.id for rmse in self]),
+            columns=["rmse"],
         )
 
     def to_csv(self, path: str):

--- a/yammbs/torsion/analysis.py
+++ b/yammbs/torsion/analysis.py
@@ -85,3 +85,21 @@ class MeanErrorCollection(list[MeanError]):
 
     def to_csv(self, path: str):
         self.to_dataframe().to_csv(path)
+
+class JSDivergence(ImmutableModel):
+    id: int
+    js_divergence: float
+    temperature: float
+
+class JSDivergenceCollection(list[JSDivergence]):
+    def to_dataframe(self) -> "pandas.DataFrame":
+        import pandas
+
+        return pandas.DataFrame(
+            [(js_divergence.js_divergence, js_divergence.temperature) for js_divergence in self],
+            index=pandas.Index([js_divergence.id for js_divergence in self]),
+            columns=["js_divergence", "temperature"],
+        )
+
+    def to_csv(self, path: str):
+        self.to_dataframe().to_csv(path)

--- a/yammbs/torsion/analysis.py
+++ b/yammbs/torsion/analysis.py
@@ -1,12 +1,18 @@
 import logging
-from typing import TYPE_CHECKING
+from abc import ABC
+from typing import TYPE_CHECKING, Generic, Self, TypeVar
 
+import numpy
+
+from yammbs._base.array import Array
 from yammbs._base.base import ImmutableModel
+from yammbs.analysis import get_rmsd
 
 LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     import pandas
+    from openff.toolkit import Molecule
 
 
 def _normalize(qm: dict[float, float], mm: dict[float, float]) -> tuple[dict[float, float], dict[float, float]]:
@@ -25,6 +31,37 @@ def _normalize(qm: dict[float, float], mm: dict[float, float]) -> tuple[dict[flo
     }
 
 
+_ImmutableModelTypeVar = TypeVar("_ImmutableModelTypeVar", bound=ImmutableModel)
+
+
+class AnalysisMetricCollection(ABC, Generic[_ImmutableModelTypeVar], list[_ImmutableModelTypeVar]):
+    """A generic collection class for typed lists of analysis metrics."""
+
+    item_type: type[_ImmutableModelTypeVar]  # This must be set in subclasses
+
+    @classmethod
+    def get_item_type(cls) -> type[_ImmutableModelTypeVar]:
+        """Retrieve the type of items in the collection (_ImmutableModelTypeVar)."""
+        if not hasattr(cls, "item_type") or cls.item_type is None:
+            raise NotImplementedError(f"{cls.__name__} must define the 'item_type' class variable.")
+        return cls.item_type
+
+    def to_dataframe(self) -> "pandas.DataFrame":
+        """Convert the collection to a pandas DataFrame."""
+        import pandas
+
+        item_type = self.get_item_type()
+        return pandas.DataFrame(
+            [element.__dict__ for element in self],
+            index=pandas.Index([element.id for element in self]),
+            columns=[field for field in item_type.model_fields.keys() if field != "id"],
+        )
+
+    def to_csv(self, path: str):
+        """Save the collection to a CSV file."""
+        self.to_dataframe().to_csv(path)
+
+
 class Minima(ImmutableModel):
     id: int
     minima: list[float]
@@ -34,74 +71,90 @@ class RMSD(ImmutableModel):
     id: int
     rmsd: float
 
-
-class RMSDCollection(list[RMSD]):
-    def to_dataframe(self) -> "pandas.DataFrame":
-        import pandas
-
-        return pandas.DataFrame(
-            [rmsd.rmsd for rmsd in self],
-            index=pandas.Index([rmsd.id for rmsd in self]),
-            columns=["rmsd"],
+    @classmethod
+    def from_data(cls, molecule_id: int, molecule: "Molecule", qm_points: Array, mm_points: Array) -> Self:
+        """Create an RMSD object by calculating the RMSD between QM and MM points."""
+        rmsd_vals = numpy.array([get_rmsd(molecule, qm_points[key], mm_points[key]) for key in qm_points])
+        return cls(
+            id=molecule_id,
+            rmsd=numpy.sqrt((rmsd_vals**2).mean()),
         )
 
-    def to_csv(self, path: str):
-        self.to_dataframe().to_csv(path)
+
+class RMSDCollection(AnalysisMetricCollection[RMSD]):
+    item_type = RMSD
 
 
 class RMSE(ImmutableModel):
     id: int
     rmse: float
 
-
-class RMSECollection(list[RMSE]):
-    def to_dataframe(self) -> "pandas.DataFrame":
-        import pandas
-
-        return pandas.DataFrame(
-            [rmse.rmse for rmse in self],
-            index=pandas.Index([rmse.id for rmse in self]),
-            columns=["rmse"],
+    @classmethod
+    def from_data(cls, molecule_id: int, qm_energies: Array, mm_energies: Array) -> Self:
+        """Create an RMSE object by calculating the RMSE between QM and MM energies."""
+        return cls(
+            id=molecule_id,
+            rmse=numpy.sqrt(((qm_energies - mm_energies) ** 2).mean()),
         )
 
-    def to_csv(self, path: str):
-        self.to_dataframe().to_csv(path)
+
+class RMSECollection(AnalysisMetricCollection[RMSE]):
+    item_type = RMSE
 
 
 class MeanError(ImmutableModel):
     id: int
     mean_error: float
 
-
-class MeanErrorCollection(list[MeanError]):
-    def to_dataframe(self) -> "pandas.DataFrame":
-        import pandas
-
-        return pandas.DataFrame(
-            [mean_error.mean_error for mean_error in self],
-            index=pandas.Index([mean_error.id for mean_error in self]),
-            columns=["mean_error"],
+    @classmethod
+    def from_data(cls, molecule_id: int, qm_energies: Array, mm_energies: Array) -> Self:
+        """Create a MeanError object by calculating the mean MM - QM energy."""
+        return cls(
+            id=molecule_id,
+            mean_error=numpy.mean(mm_energies - qm_energies),
         )
 
-    def to_csv(self, path: str):
-        self.to_dataframe().to_csv(path)
+
+class MeanErrorCollection(AnalysisMetricCollection[MeanError]):
+    item_type = MeanError
 
 
-class JSDivergence(ImmutableModel):
+class JSDistance(ImmutableModel):
     id: int
-    js_divergence: float
-    temperature: float
+    js_distance: float
+    js_temperature: float
 
+    @classmethod
+    def from_data(
+        cls,
+        molecule_id: int,
+        qm_energies: Array,
+        mm_energies: Array,
+        temperature: float,
+    ) -> Self:
+        """
+        Create a JSDistance object by calculating the Jensen-Shannon distance
+        between the two distributions generated with Boltzmann inversion at the
+        specified temperature, using base 2 logs.  A distance of 0 indicates
+        identical distributions, while a distance of 1 indicates completely
+        non-overlapping distributions.
+        """
+        from scipy.spatial.distance import jensenshannon
 
-class JSDivergenceCollection(list[JSDivergence]):
-    def to_dataframe(self) -> "pandas.DataFrame":
-        import pandas
+        beta = 1.0 / (temperature * 0.0019872043)  # kcal/mol to K
 
-        return pandas.DataFrame(
-            [(js_divergence.js_divergence, js_divergence.temperature) for js_divergence in self],
-            index=pandas.Index([js_divergence.id for js_divergence in self]),
-            columns=["js_divergence", "temperature"],
+        # Get normalised probabilities by Boltzmann inversion
+        p_qm, p_mm = numpy.exp(-beta * qm_energies), numpy.exp(-beta * mm_energies)
+        p_qm /= p_qm.sum()
+        p_mm /= p_mm.sum()
+
+        return cls(
+            id=molecule_id,
+            # Use base 2 so that the upper limit is 1
+            js_distance=jensenshannon(p_qm, p_mm, base=2),
+            js_temperature=temperature,
         )
 
-    def to_csv(self, path: str):
-        self.to_dataframe().to_csv(path)
+
+class JSDistanceCollection(AnalysisMetricCollection[JSDistance]):
+    item_type = JSDistance

--- a/yammbs/torsion/analysis.py
+++ b/yammbs/torsion/analysis.py
@@ -66,3 +66,22 @@ class RMSECollection(list[RMSE]):
 
     def to_csv(self, path: str):
         self.to_dataframe().to_csv(path)
+
+
+class MeanError(ImmutableModel):
+    id: int
+    mean_error: float
+
+
+class MeanErrorCollection(list[MeanError]):
+    def to_dataframe(self) -> "pandas.DataFrame":
+        import pandas
+
+        return pandas.DataFrame(
+            [mean_error.mean_error for mean_error in self],
+            index=pandas.Index([mean_error.id for mean_error in self]),
+            columns=["mean_error"],
+        )
+
+    def to_csv(self, path: str):
+        self.to_dataframe().to_csv(path)

--- a/yammbs/torsion/analysis.py
+++ b/yammbs/torsion/analysis.py
@@ -86,10 +86,12 @@ class MeanErrorCollection(list[MeanError]):
     def to_csv(self, path: str):
         self.to_dataframe().to_csv(path)
 
+
 class JSDivergence(ImmutableModel):
     id: int
     js_divergence: float
     temperature: float
+
 
 class JSDivergenceCollection(list[JSDivergence]):
     def to_dataframe(self) -> "pandas.DataFrame":

--- a/yammbs/torsion/outputs.py
+++ b/yammbs/torsion/outputs.py
@@ -45,6 +45,7 @@ class Metric(ImmutableModel):
     mean_error: float
     js_divergence: tuple[float, float]
 
+
 class MetricCollection(ImmutableModel):
     metrics: dict[str, dict[int, Metric]] = Field(
         dict(),

--- a/yammbs/torsion/outputs.py
+++ b/yammbs/torsion/outputs.py
@@ -41,7 +41,7 @@ class MinimizedTorsionDataset(ImmutableModel):
 
 class Metric(ImmutableModel):
     rmsd: float
-    een: float
+    rmse: float
 
 
 class MetricCollection(ImmutableModel):

--- a/yammbs/torsion/outputs.py
+++ b/yammbs/torsion/outputs.py
@@ -43,7 +43,7 @@ class Metric(ImmutableModel):
     rmsd: float
     rmse: float
     mean_error: float
-
+    js_divergence: tuple[float, float]
 
 class MetricCollection(ImmutableModel):
     metrics: dict[str, dict[int, Metric]] = Field(

--- a/yammbs/torsion/outputs.py
+++ b/yammbs/torsion/outputs.py
@@ -43,7 +43,7 @@ class Metric(ImmutableModel):
     rmsd: float
     rmse: float
     mean_error: float
-    js_divergence: tuple[float, float]
+    js_distance: tuple[float, float]
 
 
 class MetricCollection(ImmutableModel):

--- a/yammbs/torsion/outputs.py
+++ b/yammbs/torsion/outputs.py
@@ -42,6 +42,7 @@ class MinimizedTorsionDataset(ImmutableModel):
 class Metric(ImmutableModel):
     rmsd: float
     rmse: float
+    mean_error: float
 
 
 class MetricCollection(ImmutableModel):


### PR DESCRIPTION
This PR:

- Changes/ adds torsion analysis metrics that I've found useful. I removed the EEN metric as from my understanding this scales with the number of points evaluated, and replaced it with RMSE. Very happy to revert this if I'm misunderstanding its use though. I've also added mean error, which I've found useful for diagnosing general over-estimation of barriers, and JS distance as discussed in the meetings (using base 2, so it varies between 0 (identical distributions) and 1 (no overlap).
- Adds a script to automate torsion analysis which is exposed as `yammbs_analyse_torsions`

Some things which may be problematic:

- I'm unsure if the way I've exposed the analysis script is best
- The temperature in the JS distance metric is passed without units
- I'm not sure if the way I've organised the calculation of metrics is great, e.g. there is now an `AnalysisMetricCollection` class as well as the `MetricCollection` class.

I spent a while trying to figure out why I was getting systematically lower RMSD results than e.g. reported [here](https://arxiv.org/abs/2312.15211) and found this was due to 1) having the RMSD restraint on non-torsion atoms during minimisation 2) using OpenMM rather than geomeTRIC and 3) calculating heavy-atom RMSD rather than including Hs.

I'll open separate PRs to discuss changing the default minimisation procedure (we had a chat with Lily this morning), and if it's useful, another which modifies the torsion store to generate a sortable html summary.

Any feedback appreciated! Thanks.