### PR TITLE
Use `torsion_id` throughout `TorsionStore`

### DIFF
--- a/yammbs/_tests/unit_tests/torsion/test_minimize.py
+++ b/yammbs/_tests/unit_tests/torsion/test_minimize.py
@@ -10,7 +10,7 @@ def ethane_input() -> ConstrainedMinimizationInput:
     ethane.generate_conformers(n_conformers=1)
 
     return ConstrainedMinimizationInput(
-        molecule_id=100,
+        torsion_id=100,
         mapped_smiles=ethane.to_smiles(mapped=True),
         dihedral_indices=[0, 1, 2, 3],
         force_field="openff-2.0.0",

--- a/yammbs/_tests/unit_tests/torsion/test_store.py
+++ b/yammbs/_tests/unit_tests/torsion/test_store.py
@@ -61,10 +61,6 @@ def test_minimize_basic(single_torsion_dataset, tmp_path):
 
     torsion_id = store.get_torsion_ids()[0]
 
-    assert len(store.get_mm_points_by_torsion_id(torsion_id, force_field="openff-2.2.0")) == len(
-        store.get_mm_points_by_torsion_id(torsion_id, force_field="openff-2.2.0"),
-    )
-
     assert store.get_force_fields() == ["openff-2.2.0"]
 
     # stored outputs include MM profiles for 1 molecule with 1 force field

--- a/yammbs/_tests/unit_tests/torsion/test_store.py
+++ b/yammbs/_tests/unit_tests/torsion/test_store.py
@@ -1,3 +1,4 @@
+import numpy
 import os
 
 from openff.qcsubmit.results import TorsionDriveResultCollection
@@ -40,9 +41,15 @@ class TestTorsionStore:
             database_name=tmp_path / "tmp.sqlite",
         )
 
-        assert store.get_qm_points_by_molecule_id(1) != store.get_qm_points_by_molecule_id(2)
-        assert store.get_dihedral_indices_by_molecule_id(1) == store.get_dihedral_indices_by_molecule_id(2)
-        assert store.get_smiles_by_molecule_id(1) == store.get_smiles_by_molecule_id(2)
+        # these ints are torsion IDs, same as the record IDs in the source data
+        assert not numpy.allclose(
+             [*store.get_qm_points_by_torsion_id(21272423).values()],
+             [*store.get_qm_points_by_torsion_id(120098113).values()],
+        )
+
+        assert store.get_dihedral_indices_by_torsion_id(21272423) == store.get_dihedral_indices_by_torsion_id(120098113)
+
+        assert store.get_smiles_by_torsion_id(21272423) == store.get_smiles_by_torsion_id(120098113)
 
 def test_minimize_basic(single_torsion_dataset, tmp_path):
     store = TorsionStore.from_torsion_dataset(
@@ -52,10 +59,10 @@ def test_minimize_basic(single_torsion_dataset, tmp_path):
 
     store.optimize_mm(force_field="openff-2.2.0", n_processes=os.cpu_count())
 
-    molecule_id = store.get_molecule_ids()[0]
+    torsion_id = store.get_torsion_ids()[0]
 
-    assert len(store.get_mm_points_by_molecule_id(molecule_id, force_field="openff-2.2.0")) == len(
-        store.get_mm_points_by_molecule_id(molecule_id, force_field="openff-2.2.0"),
+    assert len(store.get_mm_points_by_torsion_id(torsion_id, force_field="openff-2.2.0")) == len(
+        store.get_mm_points_by_torsion_id(torsion_id, force_field="openff-2.2.0"),
     )
 
     assert store.get_force_fields() == ["openff-2.2.0"]

--- a/yammbs/torsion/_db.py
+++ b/yammbs/torsion/_db.py
@@ -11,11 +11,12 @@ class DBTorsionRecord(DBBase):  # type: ignore
 
     id = Column(Integer, primary_key=True, index=True)
 
+    torsion_id = Column(Integer, nullable=False, index=True)
+
     inchi_key = Column(String, nullable=False, index=True)
     mapped_smiles = Column(String, nullable=False)
 
     dihedral_indices = Column(PickleType, nullable=False)
-    qcarchive_id = Column(Integer, nullable=False)
 
 
 class DBTorsionProfileRecord(DBBase):  # type: ignore

--- a/yammbs/torsion/_minimize.py
+++ b/yammbs/torsion/_minimize.py
@@ -14,11 +14,9 @@ LOGGER = logging.getLogger(__name__)
 
 
 class ConstrainedMinimizationInput(ImmutableModel):
-    # This is more like a "TorsionDrive" ID than a molecule ID,
-    # but it's how the database is currently structured.
-    molecule_id: int = Field(
+    torsion_id: int = Field(
         ...,
-        description="The identifier of the molecule",
+        description="The identifier of the torsion unit",
     )
     mapped_smiles: str = Field(
         ...,
@@ -72,14 +70,14 @@ def _minimize_torsions(
     # from inside of TorsionStore
     inputs: Generator[ConstrainedMinimizationInput, None, None] = (
         ConstrainedMinimizationInput(
-            molecule_id=molecule_id,
+            torsion_id=torsion_id,
             mapped_smiles=mapped_smiles,
             dihedral_indices=dihedral_indices,
             force_field=force_field,
             coordinates=coordinates,
             grid_id=grid_id,
         )
-        for (molecule_id, mapped_smiles, dihedral_indices, grid_id, coordinates, _) in data
+        for (torsion_id, mapped_smiles, dihedral_indices, grid_id, coordinates, _) in data
     )
 
     LOGGER.info("Setting up multiprocessing pool with generator (of unknown length)")
@@ -201,7 +199,7 @@ def _minimize_constrained(
 
     LOGGER.debug("Returning result")
     return ConstrainedMinimizationResult(
-        molecule_id=input.molecule_id,
+        torsion_id=input.torsion_id,
         mapped_smiles=input.mapped_smiles,
         dihedral_indices=input.dihedral_indices,
         force_field=input.force_field,

--- a/yammbs/torsion/_session.py
+++ b/yammbs/torsion/_session.py
@@ -8,17 +8,17 @@ class TorsionDBSessionManager(DBSessionManager):
     def store_torsion_record(self, record: TorsionRecord):
         self.db.add(
             DBTorsionRecord(
+                torsion_id=record.torsion_id,
                 mapped_smiles=record.mapped_smiles,
                 inchi_key=record.inchi_key,
                 dihedral_indices=record.dihedral_indices,
-                qcarchive_id=record.qcarchive_id,
             ),
         )
 
     def store_qm_torsion_point(self, record: QMTorsionPointRecord):
         self.db.add(
             DBQMTorsionPointRecord(
-                parent_id=record.molecule_id,
+                parent_id=record.torsion_id,
                 grid_id=record.grid_id,
                 coordinates=record.coordinates,
                 energy=record.energy,
@@ -28,7 +28,7 @@ class TorsionDBSessionManager(DBSessionManager):
     def store_mm_torsion_point(self, record: MMTorsionPointRecord):
         self.db.add(
             DBMMTorsionPointRecord(
-                parent_id=record.molecule_id,
+                parent_id=record.torsion_id,
                 grid_id=record.grid_id,
                 coordinates=record.coordinates,
                 force_field=record.force_field,

--- a/yammbs/torsion/_store.py
+++ b/yammbs/torsion/_store.py
@@ -98,7 +98,7 @@ class TorsionStore:
         with self._get_session() as db:
             db.store_mm_torsion_point(point)
 
-    def get_molecule_ids(self) -> list[int]:
+    def get_torsion_ids(self) -> list[int]:
         """Get the molecule IDs of all records in the store.
 
         These are likely to be integers sequentially incrementing from 1, but that
@@ -106,36 +106,24 @@ class TorsionStore:
         """
         # TODO: This isn't really a "molecule ID", it's more like a torsiondrive ID
         with self._get_session() as db:
-            return [molecule_id for (molecule_id,) in db.db.query(DBTorsionRecord.id).distinct()]
+            return [torsion_id for (torsion_id,) in db.db.query(DBTorsionRecord.torsion_id).distinct()]
 
-    # TODO: Allow by multiple selectors (how to do with multiple args? 1-arg case is smiles: list[str])
-    def get_molecule_id_by_smiles_and_dihedral_indices(
-        self,
-        smiles: str,
-        dihedral_indices: tuple[int, int, int, int],
-    ) -> int:
+    # TODO: Allow by multiple selectors (id: list[int])
+    def get_smiles_by_torsion_id(self, torsion_id: int) -> str:
         with self._get_session() as db:
             return next(
-                id
-                for (id,) in db.db.query(DBTorsionRecord.id)
-                .filter_by(
-                    mapped_smiles=smiles,
-                    dihedral_indices=dihedral_indices,
-                )
-                .all()
+                smiles
+                for (smiles,) in db.db.query(DBTorsionRecord.mapped_smiles).filter_by(torsion_id=torsion_id).all()
             )
 
     # TODO: Allow by multiple selectors (id: list[int])
-    def get_smiles_by_molecule_id(self, id: int) -> str:
-        with self._get_session() as db:
-            return next(smiles for (smiles,) in db.db.query(DBTorsionRecord.mapped_smiles).filter_by(id=id).all())
-
-    # TODO: Allow by multiple selectors (id: list[int])
-    def get_dihedral_indices_by_molecule_id(self, id: int) -> tuple[int, int, int, int]:
+    def get_dihedral_indices_by_torsion_id(self, torsion_id: int) -> tuple[int, int, int, int]:
         with self._get_session() as db:
             return next(
                 dihedral_indices
-                for (dihedral_indices,) in db.db.query(DBTorsionRecord.dihedral_indices).filter_by(id=id).all()
+                for (dihedral_indices,) in db.db.query(DBTorsionRecord.dihedral_indices)
+                .filter_by(torsion_id=torsion_id)
+                .all()
             )
 
     def get_force_fields(
@@ -150,7 +138,7 @@ class TorsionStore:
                 ).distinct()
             ]
 
-    def get_qm_points_by_molecule_id(self, id: int) -> dict[float, NDArray]:
+    def get_qm_points_by_torsion_id(self, torsion_id: int) -> dict[float, NDArray]:
         with self._get_session() as db:
             return {
                 grid_id: coordinates
@@ -158,13 +146,13 @@ class TorsionStore:
                     DBQMTorsionPointRecord.grid_id,
                     DBQMTorsionPointRecord.coordinates,
                 )
-                .filter_by(parent_id=id)
+                .filter_by(parent_id=torsion_id)
                 .all()
             }
 
-    def get_mm_points_by_molecule_id(
+    def get_mm_points_by_torsion_id(
         self,
-        id: int,
+        torsion_id: int,
         force_field: str,
     ) -> dict[float, NDArray]:
         with self._get_session() as db:
@@ -174,12 +162,12 @@ class TorsionStore:
                     DBMMTorsionPointRecord.grid_id,
                     DBMMTorsionPointRecord.coordinates,
                 )
-                .filter_by(parent_id=id)
+                .filter_by(parent_id=torsion_id)
                 .filter_by(force_field=force_field)
                 .all()
             }
 
-    def get_qm_energies_by_molecule_id(self, id: int) -> dict[float, float]:
+    def get_qm_energies_by_torsion_id(self, torsion_id: int) -> dict[float, float]:
         with self._get_session() as db:
             return {
                 grid_id: energy
@@ -187,11 +175,11 @@ class TorsionStore:
                     DBQMTorsionPointRecord.grid_id,
                     DBQMTorsionPointRecord.energy,
                 )
-                .filter_by(parent_id=id)
+                .filter_by(parent_id=torsion_id)
                 .all()
             }
 
-    def get_mm_energies_by_molecule_id(self, id: int, force_field: str) -> dict[float, float]:
+    def get_mm_energies_by_torsion_id(self, torsion_id: int, force_field: str) -> dict[float, float]:
         with self._get_session() as db:
             return {
                 grid_id: energy
@@ -199,7 +187,7 @@ class TorsionStore:
                     DBMMTorsionPointRecord.grid_id,
                     DBMMTorsionPointRecord.energy,
                 )
-                .filter_by(parent_id=id)
+                .filter_by(parent_id=torsion_id)
                 .filter_by(force_field=force_field)
                 .all()
             }
@@ -223,22 +211,22 @@ class TorsionStore:
         LOGGER.info("Iterating through qm_torsions field of QCArchiveTorsionDataset (which is a YAMMBS model).")
 
         for qm_torsion in dataset.qm_torsions:
+            # TODO: Adapt this for non-QCArchive datasets like TorsionNet500
+            this_id = qm_torsion.qcarchive_id
+
             torsion_record = TorsionRecord(
+                torsion_id=this_id,
                 mapped_smiles=qm_torsion.mapped_smiles,
                 inchi_key=_smiles_to_inchi_key(qm_torsion.mapped_smiles),
                 dihedral_indices=qm_torsion.dihedral_indices,
-                qcarchive_id=qm_torsion.qcarchive_id,
             )
 
             store.store_torsion_record(torsion_record)
 
             for angle in qm_torsion.coordinates:
                 qm_point_record = QMTorsionPointRecord(
-                    molecule_id=store.get_molecule_id_by_smiles_and_dihedral_indices(
-                        smiles=torsion_record.mapped_smiles,
-                        dihedral_indices=torsion_record.dihedral_indices,
-                    ),
-                    grid_id=angle,  # TODO: This needs to be a tuple later
+                    torsion_id=this_id,
+                    grid_id=angle,  # TODO: This needs to be a tuple later for 2D scans
                     coordinates=qm_torsion.coordinates[angle],
                     energy=qm_torsion.energies[angle],
                 )
@@ -275,18 +263,18 @@ class TorsionStore:
 
         from yammbs.torsion._minimize import _minimize_torsions
 
-        molecule_ids = self.get_molecule_ids()
+        torsion_ids = self.get_torsion_ids()
 
         # TODO Do this by interacting with the database in one step?
         ids_to_minimize = [
-            molecule_id
-            for molecule_id in molecule_ids
-            if len(self.get_mm_points_by_molecule_id(molecule_id, force_field)) == 0
+            torsion_id
+            for torsion_id in torsion_ids
+            if len(self.get_mm_points_by_torsion_id(torsion_id, force_field)) == 0
         ]
 
-        id_to_smiles = {molecule_id: self.get_smiles_by_molecule_id(molecule_id) for molecule_id in ids_to_minimize}
+        id_to_smiles = {torsion_id: self.get_smiles_by_torsion_id(torsion_id) for torsion_id in ids_to_minimize}
         id_to_dihedral_indices = {
-            molecule_id: self.get_dihedral_indices_by_molecule_id(molecule_id) for molecule_id in ids_to_minimize
+            torsion_id: self.get_dihedral_indices_by_torsion_id(torsion_id) for torsion_id in ids_to_minimize
         }
 
         LOGGER.info(f"Setting up generator of data for minimization with {force_field=}")
@@ -306,14 +294,14 @@ class TorsionStore:
                 None,
             ] = (  # Probably a better way to do this with some proper database query with join
                 (
-                    molecule_id,
-                    id_to_smiles[molecule_id],
-                    id_to_dihedral_indices[molecule_id],
+                    torsion_id,
+                    id_to_smiles[torsion_id],
+                    id_to_dihedral_indices[torsion_id],
                     grid_id,
                     coordinates,
                     energy,
                 )
-                for (molecule_id, grid_id, coordinates, energy) in db.db.query(
+                for (torsion_id, grid_id, coordinates, energy) in db.db.query(
                     DBQMTorsionPointRecord.parent_id,
                     DBQMTorsionPointRecord.grid_id,
                     DBQMTorsionPointRecord.coordinates,
@@ -337,7 +325,7 @@ class TorsionStore:
             for result in minimization_results:
                 db.store_mm_torsion_point(
                     MMTorsionPointRecord(
-                        molecule_id=result.molecule_id,
+                        torsion_id=result.torsion_id,
                         grid_id=result.grid_id,
                         coordinates=result.coordinates,
                         force_field=result.force_field,
@@ -348,14 +336,14 @@ class TorsionStore:
     def get_rmsd(
         self,
         force_field: str,
-        molecule_ids: list[int] | None = None,
+        torsion_ids: list[int] | None = None,
         skip_check: bool = False,
     ) -> RMSDCollection:
         """Get the RMSD summed over the torsion profile."""
         from openff.toolkit import Molecule
 
-        if not molecule_ids:
-            molecule_ids = self.get_molecule_ids()
+        if not torsion_ids:
+            torsion_ids = self.get_torsion_ids()
 
         if not skip_check:
             # TODO: Copy this into each get_* method?
@@ -364,18 +352,18 @@ class TorsionStore:
 
         rmsds = RMSDCollection()
 
-        for molecule_id in molecule_ids:
-            qm_points = self.get_qm_points_by_molecule_id(id=molecule_id)
-            mm_points = self.get_mm_points_by_molecule_id(id=molecule_id, force_field=force_field)
+        for torsion_id in torsion_ids:
+            qm_points = self.get_qm_points_by_torsion_id(torsion_id=torsion_id)
+            mm_points = self.get_mm_points_by_torsion_id(torsion_id=torsion_id, force_field=force_field)
 
             molecule = Molecule.from_mapped_smiles(
-                self.get_smiles_by_molecule_id(molecule_id),
+                self.get_smiles_by_torsion_id(torsion_id),
                 allow_undefined_stereo=True,
             )
 
             rmsds.append(
                 RMSD(
-                    id=molecule_id,
+                    id=torsion_id,
                     rmsd=sum(get_rmsd(molecule, qm_points[key], mm_points[key]) for key in qm_points),
                 ),
             )
@@ -385,36 +373,36 @@ class TorsionStore:
     def get_een(
         self,
         force_field: str,
-        molecule_ids: list[int] | None = None,
+        torsion_ids: list[int] | None = None,
         skip_check: bool = False,
     ) -> EENCollection:
         """Get the vector norm of the energy errors over the torsion profile."""
-        if not molecule_ids:
-            molecule_ids = self.get_molecule_ids()
+        if not torsion_ids:
+            torsion_ids = self.get_torsion_ids()
 
         if not skip_check:
             self.optimize_mm(force_field=force_field)
 
         eens = EENCollection()
 
-        for molecule_id in molecule_ids:
+        for torsion_id in torsion_ids:
             qm, mm = (
                 numpy.fromiter(dct.values(), dtype=float)
                 for dct in _normalize(
-                    self.get_qm_energies_by_molecule_id(id=molecule_id),
-                    self.get_mm_energies_by_molecule_id(id=molecule_id, force_field=force_field),
+                    self.get_qm_energies_by_torsion_id(torsion_id=torsion_id),
+                    self.get_mm_energies_by_torsion_id(torsion_id=torsion_id, force_field=force_field),
                 )
             )
 
             if len(mm) * len(qm) == 0:
                 LOGGER.warning(
                     "Missing QM OR MM data for this no mm data, returning empty dicts; \n\t"
-                    f"{molecule_id=}, {force_field=}, {len(qm)=}, {len(mm)=}",
+                    f"{torsion_id=}, {force_field=}, {len(qm)=}, {len(mm)=}",
                 )
 
             eens.append(
                 EEN(
-                    id=molecule_id,
+                    id=torsion_id,
                     een=numpy.linalg.norm(qm - mm),
                 ),
             )
@@ -432,7 +420,7 @@ class TorsionStore:
             for force_field in self.get_force_fields():
                 output_dataset.mm_torsions[force_field] = list()
 
-                for molecule_id in self.get_molecule_ids():
+                for torsion_id in self.get_torsion_ids():
                     mm_data = tuple(
                         (grid_id, coordinates, energy)
                         for (grid_id, coordinates, energy) in db.db.query(
@@ -440,7 +428,7 @@ class TorsionStore:
                             DBMMTorsionPointRecord.coordinates,
                             DBMMTorsionPointRecord.energy,
                         )
-                        .filter_by(parent_id=molecule_id)
+                        .filter_by(parent_id=torsion_id)
                         .filter_by(force_field=force_field)
                         .all()
                     )
@@ -451,8 +439,8 @@ class TorsionStore:
                     # TODO: Call _normalize here?
                     output_dataset.mm_torsions[force_field].append(
                         MinimizedTorsionProfile(
-                            mapped_smiles=self.get_smiles_by_molecule_id(molecule_id),
-                            dihedral_indices=self.get_dihedral_indices_by_molecule_id(molecule_id),
+                            mapped_smiles=self.get_smiles_by_torsion_id(torsion_id),
+                            dihedral_indices=self.get_dihedral_indices_by_torsion_id(torsion_id),
                             coordinates={grid_id: coordinates for grid_id, coordinates, _ in mm_data},
                             energies={grid_id: energy for grid_id, _, energy in mm_data},
                         ),

--- a/yammbs/torsion/models.py
+++ b/yammbs/torsion/models.py
@@ -9,22 +9,22 @@ from yammbs.models import MoleculeRecord, Record
 class TorsionRecord(MoleculeRecord):
     """Base class for torsion records."""
 
+    torsion_id: int = Field(
+        ...,
+        description="The ID of the torsion profile in the database",
+    )
     dihedral_indices: tuple[int, int, int, int] = Field(
         ...,
         description="The indices of the atoms which define the driven dihedral angle",
-    )
-    qcarchive_id: int = Field(
-        ...,
-        description="The record ID of the torsion drive as stored in QCArchive.",
     )
 
 
 class QMTorsionPointRecord(Record):
     """A record for a specific 'point' in a torsion scan."""
 
-    molecule_id: int = Field(
+    torsion_id: int = Field(
         ...,
-        description="The ID of the molecule in the database",
+        description="The ID of the torsion profile in the database",
     )
 
     # TODO: This needs to be a tuple[float] for 2D grids?


### PR DESCRIPTION
(Another attempt at) fixes #131

There's more work to be done but I _think_ this fixes the basic problem. I used the JSON from the linked issue to do a minimal analysis in which I show that
* torsion profiles for multiple force fields pass the eye test comparing to QM, though in this case they're hard to distinguish visually
* different "torsions" have quantitatively different metrics

See rendered live (link might not last forever): https://static.marimo.app/static/torsion-redo-demo-zejx