### PR TITLE
Fix pip install git+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = {text = "MIT"}
 dynamic = ["version"]
 
 [tool.setuptools]
-packages = ["yammbs"]
+packages.find = {}
 
 [tool.versioningit]
 


### PR DESCRIPTION
This fixes remote installs of yammbs using `git+https://github.com/openforcefield/yammbs.git`.

My understanding is that when we use e.g. `pip install -e .` there's no issue as Python can import straight from the source, but `git+https://github.com/openforcefield/yammbs.git` first builds a wheel and 

```
[tool.setuptools]
packages = ["yammbs"]
```
only `yammbs` (and not `yammbs._base` etc.) get included.

I've verified this solves the issue by running
```
pip install git+https://github.com/openforcefield/yammbs.git@bugfix-git-installation
```
and checking that
```Python
from yammbs.torsion._store import TorsionStore
```
works (which was broken before). 

Thanks.
